### PR TITLE
Feature/confirm save on deactivate

### DIFF
--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -1956,10 +1956,10 @@
             var unsavedFeatures = widget.unsavedFeatures;
             widget.unsavedFeatures = {};
             var always = function() {
+                widget.options.__disabled = true;
                 if(!widget.currentSettings.displayOnInactive) {
                     widget.deactivateFrame(widget.currentSettings);
                 }
-                widget.options.__disabled = true;
             };
             if (widget.options.confirmSaveOnDeactivate) {
                 widget._confirmSave(unsavedFeatures, always);
@@ -2010,6 +2010,8 @@
                     }
                 };
                 Mapbender.confirmDialog(confirmOptions);
+            } else {
+                callback();
             }
         },
 

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -1973,12 +1973,12 @@
             if (numUnsaved) {
                 var html = "<p>Sie haben "
                     + ((numUnsaved > 1) ?
-                        "" + numUnsaved + " ungespeicherte &Auml;nderungen"
-                        : "eine ungespeicherte &Auml;nderung")
-                    + " vorgenommen</p>"
-                    + "<p>Wollen sie diese speichern oder verwerfen?</p>";
+                        "" + numUnsaved + " &Auml;nderungen"
+                        : "eine &Auml;nderung")
+                    + " vorgenommen und noch nicht gespeichert.</p>"
+                    + "<p>Wollen sie diese jetzt speichern oder verwerfen?</p>";
                 var confirmOptions = {
-                    okText:     "Speichern",
+                    okText:     "Jetzt Speichern",
                     cancelText: "Verwerfen",
                     html:       html,
                     title:      "Ungespeicherte Änderungen",

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -666,44 +666,6 @@
                 map.addControl(selectControl);
             });
 
-            function deactivateFrame(schema) {
-                var frame = schema.frame;
-                //var tableApi = schema.table.resultTable('getApi');
-                var layer = schema.layer;
-
-                frame.css('display', 'none');
-
-                if(!schema.displayPermanent){
-                    layer.setVisibility(false);
-                }
-
-                schema.selectControl.deactivate();
-
-                // https://trac.wheregroup.com/cp/issues/4548
-                if(widget.currentPopup){
-                    widget.currentPopup.popupDialog('close');
-                }
-
-
-                //layer.redraw();
-                //layer.removeAllFeatures();
-                //tableApi.clear();
-            }
-
-            function activateFrame(schema) {
-                var frame = schema.frame;
-                var layer = schema.layer;
-
-                widget.activeLayer = schema.layer;
-                widget.schemaName = schema.schemaName;
-                widget.currentSettings = schema;
-                layer.setVisibility(true);
-                //layer.redraw();
-                frame.css('display', 'block');
-
-                schema.selectControl.activate();
-            }
-
             function onSelectorChange() {
                 var option = selector.find(":selected");
                 var schema = option.data("schemaSettings");
@@ -714,10 +676,10 @@
                 widget._trigger("beforeChangeDigitizing", null, {next: schema, previous: widget.currentSettings});
 
                 if(widget.currentSettings) {
-                    deactivateFrame(widget.currentSettings);
+                    widget.deactivateFrame(widget.currentSettings);
                 }
 
-                activateFrame(schema);
+                widget.activateFrame(schema);
 
                 table.off('mouseenter', 'mouseleave', 'click');
 
@@ -766,17 +728,14 @@
             // Check position and react by
             var containerInfo = new MapbenderContainerInfo(widget, {
                 onactive:   function() {
-                    activateFrame(widget.currentSettings);
+                    widget.activate();
                 },
                 oninactive: function() {
-                    if(!widget.currentSettings.displayOnInactive) {
-                        deactivateFrame(widget.currentSettings);
-                    }
+                    widget.deactivate();
                 }
             });
 
             widget.updateClusterStrategies();
-
         },
 
         /**
@@ -1681,6 +1640,10 @@
             tableApi.rows.add(featuresWithoutDrawElements);
             tableApi.draw();
 
+            if(widget.options.__disabled){
+                widget.deactivate();
+            }
+
             // var tbody = $(tableApi.body());
 
             // Post handling
@@ -1915,6 +1878,64 @@
                 });
                 console.log(errorMessage, xhr);
             });
+        },
+
+        activate: function() {
+            var widget = this;
+            widget.options.__disabled = false;
+            widget.activateFrame(widget.currentSettings);
+        },
+
+        deactivate: function() {
+            var widget = this;
+            widget.options.__disabled = true;
+
+            if(!widget.currentSettings.displayOnInactive) {
+                widget.deactivateFrame(widget.currentSettings);
+            }
+        },
+
+        activateFrame:   function(schema) {
+            var widget = this;
+            var frame = schema.frame;
+            var layer = schema.layer;
+
+            if(widget.options.__disabled){
+                return;
+            }
+
+            widget.activeLayer = schema.layer;
+            widget.schemaName = schema.schemaName;
+            widget.currentSettings = schema;
+
+            widget.query('style/list', {schema: schema.schemaName}).done(function(r) {
+                schema.featureStyles = r.featureStyles;
+                widget.reloadFeatures(layer);
+                layer.setVisibility(true);
+                frame.css('display', 'block');
+                schema.selectControl.activate();
+            });
+
+        },
+
+        deactivateFrame: function(schema) {
+            var widget = this;
+            var frame = schema.frame;
+            //var tableApi = schema.table.resultTable('getApi');
+            var layer = schema.layer;
+
+            frame.css('display', 'none');
+
+            if(!schema.displayPermanent) {
+                layer.setVisibility(false);
+            }
+
+            schema.selectControl.deactivate();
+
+            // https://trac.wheregroup.com/cp/issues/4548
+            if(widget.currentPopup) {
+                widget.currentPopup.popupDialog('close');
+            }
         }
     });
 

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -857,6 +857,7 @@
                     }
 
                     var hasFeatureAfterSave = response.features.length > 0;
+                    delete widget.unsavedFeatures[feature.id];
 
                     if(!hasFeatureAfterSave) {
                         widget.reloadFeatures(schema.layer, _.without(schema.layer.features, feature));
@@ -877,7 +878,6 @@
                     _.each(['fid', 'disabled', 'state', 'data', 'layer', 'schema', 'isNew', 'renderIntent'], function(key) {
                         newFeature[key] = feature[key];
                     });
-                    var oldOpenlayersId = feature.id;
 
                     widget.reloadFeatures(schema.layer, _.union(_.without(layer.features, feature), [newFeature]));
                     feature = newFeature;
@@ -886,7 +886,6 @@
                     tableApi.draw();
 
                     delete feature.isNew;
-                    delete widget.unsavedFeatures[oldOpenLayersId];
 
                     dialog && dialog.enableForm();
                     feature.disabled = false;
@@ -1972,8 +1971,12 @@
             var widget = this;
             var numUnsaved = _.size(unsavedFeatures);
             if (numUnsaved) {
-                var html = "<p>Sie haben ungespeicherte &Auml;nderungen an " + numUnsaved + "</p>"
-                    + "<p>Wollen sie diese &Auml;nderungen speichern oder verwerfen?</p>";
+                var html = "<p>Sie haben "
+                    + ((numUnsaved > 1) ?
+                        "" + numUnsaved + " ungespeicherte &Auml;nderungen"
+                        : "eine ungespeicherte &Auml;nderung")
+                    + " vorgenommen</p>"
+                    + "<p>Wollen sie diese speichern oder verwerfen?</p>";
                 var confirmOptions = {
                     okText:     "Speichern",
                     cancelText: "Verwerfen",

--- a/composer.json
+++ b/composer.json
@@ -12,17 +12,15 @@
         "php": ">=5.3.3",
         "blueimp/jquery-file-upload": "9.*",
         "mapbender/data-source": "0.*",
-        "phayes/geophp": "1.2"
+        "viscreation/vis-ui.js": "0.*"
     },
-    "require-dev": {
-        "mapbender/data-source": "@dev"
-    },
-    "minimum-stability": "dev",
     "config": {
         "bin-dir": "bin"
     },
     "autoload": {
-		"psr-0": {"Mapbender\\DigitizerBundle": "."}
+        "psr-0": {
+            "Mapbender\\DigitizerBundle": "."
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
For applications where the digitizer can be "exited" (e.g. accordion embedding) or otherwise deactivated, track unsaved geometry changes, and ask the user to save or discard them when deactivate is called.

If user chooses to save, feature changes are persisted to the database.
If user chooses to discard, feature changes are reset, new features are removed

Behaviour is controlled with a new (booleanish) widget option ``confirmSaveOnDeactivate``.

This change is layered on top of a cherry-pick of d46e4411ac143f7f732da760a13e1aea4dd035de from the feature/migrate-feature-type branch.

