### PR TITLE
Digitizer keeps reference for print widget once it has been initialized

### DIFF
--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -1029,11 +1029,12 @@
                 var printButton = {
                     text: Mapbender.digitizer_translate('feature.print'),
                     click: function () {
-                        var printWidget = $('.mb-element-printclient').data('mapbenderMbPrintClient');
-                        if (printWidget) {
+                        widget.printWidget = widget.printWidget || $('.mb-element-printclient').data('mapbenderMbPrintClient');
+
+                        if (widget.printWidget) {
                             var dialog = $(this).closest('.ui-dialog-content');
                             var feature = dialog.data('feature');
-                            printWidget.printDigitizerFeature(feature.schema.featureTypeName || feature.schema.schemaName, feature.fid);
+                            widget.printWidget.printDigitizerFeature(feature.schema.featureTypeName || feature.schema.schemaName, feature.fid);
                         } else {
                             $.notify('Druck Element ist nicht verfügbar!');
                         }


### PR DESCRIPTION
This is necessary since the wrapping element (.mb-element-printclient) is removed from the DOM when the print widget is closed.