### PR TITLE
Adjust Deactivation/Activation of Scheme

### DIFF
--- a/Resources/public/digitizerSchema.js
+++ b/Resources/public/digitizerSchema.js
@@ -227,13 +227,18 @@ var Scheme = OpenLayers.Class({
         widget.schemaName = schema.schemaName;
         widget.currentSettings = schema;
 
-        widget.query('style/list', {schema: schema.schemaName}).done(function (r) {
-            schema.featureStyles = r.featureStyles;
-            widget.reloadFeatures(layer);
-            layer.setVisibility(true);
-            frame.css('display', 'block');
-            schema.selectControl.activate();
-        });
+        // widget.query('style/list', {schema: schema.schemaName}).done(function (r) {
+        //     schema.featureStyles = r.featureStyles;
+        //     widget.reloadFeatures(layer);
+        //     layer.setVisibility(true);
+        //     frame.css('display', 'block');
+        //     schema.selectControl.activate();
+        // });
+
+        widget.reloadFeatures(layer);
+        layer.setVisibility(true);
+        frame.css('display', 'block');
+        schema.selectControl.activate();
 
     },
 

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -697,9 +697,15 @@
             _.each(widget.options.schemes, function(el,index){
                 el.widget = widget;
                 newSchemes[index] = new Scheme(el);
+
+                widget.activeLayer = widget.activeLayer || newSchemes[index].layer;
+                widget.schemaName = widget.schemaName || newSchemes[index].schemaName;
+                widget.currentSettings = widget.currentSettings || newSchemes[index];
             });
 
            widget.options.schemes = newSchemes;
+
+           
 
 
             /**
@@ -728,9 +734,11 @@
 
                 if (widget.currentSettings) {
                     widget.currentSettings.deactivateSchema();
+                } 
+                
+                if (widget.currentSettings.schemaName != schema.schemaName || schema.displayOnInactive || schema.displayPermanent) {
+                    schema.activateSchema();
                 }
-
-                schema.activateSchema();
 
                 table.off('mouseenter', 'mouseleave', 'click');
 


### PR DESCRIPTION
- Deavtivate loading of featureStyles - its not implemented yet and causes problems due to asynchronity
- Set a scheme as "currentSetting" as soon as the schemes are created
- Activate Scheme after Selectorchange only when scheme differs from the one that was deactivated before or when scheme is configured to stay visible.