### PR TITLE
Fix/bring your own print attributes

### DIFF
--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -897,7 +897,7 @@
                         if(printWidget) {
                             var dialog = $(this).closest(".ui-dialog-content");
                             var olFeature = dialog.data('feature');
-                            printWidget.printDigitizerFeature(olFeature.schema.featureTypeName ? olFeature.schema.featureTypeName : olFeature.schema.schemaName, olFeature.fid);
+                            printWidget.printDigitizerFeature(olFeature, olFeature.schema.featureTypeName || olFeature.schema.schemaName);
                         } else {
                             $.notify("Druck element ist nicht verfügbar!");
                         }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "mapbender/data-source": "0.*",
         "mapbender/vis-ui.js": "*"
     },
+    "conflict": {
+        "mapbender/mapbender": "<3.0.8"
+    },
     "config": {
         "bin-dir": "bin"
     },


### PR DESCRIPTION
This changes the invocation of Mapbender's mbPrintClient.printDigitizerFeature to supply the actual feature data.

This frees the Mapbender print backend from looking up FeatureType / DataStore services, which is completely unsafe anyway.

Every Digitizer Element can potentially define its FeatureType set in its backend configuration. Service lookup is not possible in those cases.

See https://github.com/mapbender/mapbender/pull/1123