### PR TITLE
Prevent modifications on widget.currentSettings.formItems - create a …

### DIFF
--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -998,7 +998,7 @@
                 schema.elementsTranslated = true;
             }
 
-            var formItems = JSON.parse(JSON.stringify(widget.currentSettings.formItems)); // Deep clone
+            var formItems = $.extend(true,{},widget.currentSettings.formItems);// Deep clone
 
             DataUtil.eachItem(formItems, function(item) {
 

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -998,8 +998,8 @@
                 schema.elementsTranslated = true;
             }
 
-            var formItems = $.extend(true,{},widget.currentSettings.formItems);// Deep clone
-
+            var formItems = [ $.extend(true,{},widget.currentSettings.formItems)[0]]; // Deep clone
+            
             DataUtil.eachItem(formItems, function(item) {
 
                 if(item.type == "select" && item.dataStore && item.dataStore.editable && item.dataStore.popupItems) {

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -998,8 +998,8 @@
                 schema.elementsTranslated = true;
             }
 
-            var formItems = [ $.extend(true,{},widget.currentSettings.formItems)[0]]; // Deep clone
-            
+            var formItems = $.extend(true,[], widget.currentSettings.formItems); // Deep clone
+
             DataUtil.eachItem(formItems, function(item) {
 
                 if(item.type == "select" && item.dataStore && item.dataStore.editable && item.dataStore.popupItems) {

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -998,7 +998,9 @@
                 schema.elementsTranslated = true;
             }
 
-            DataUtil.eachItem(widget.currentSettings.formItems, function(item) {
+            var formItems = JSON.parse(JSON.stringify(widget.currentSettings.formItems)); // Deep clone
+
+            DataUtil.eachItem(formItems, function(item) {
 
                 if(item.type == "select" && item.dataStore && item.dataStore.editable && item.dataStore.popupItems) {
 
@@ -1089,7 +1091,7 @@
             });
 
             dialog.data('feature', olFeature);
-            dialog.generateElements({children: widget.currentSettings.formItems});
+            dialog.generateElements({children: formItems});
             dialog.popupDialog(popupConfiguration);
             schema.editDialog = dialog;
             widget.currentPopup = dialog;


### PR DESCRIPTION
…deep copy of the formItems when opening featureEdit Dialog and process these copied formItems, rather than the original. This prevents bugs like unexpected data from a former featuer in the dialog