### PR TITLE
Enh/configure tool behaviour after creation

### DIFF
--- a/Element/Digitizer.php
+++ b/Element/Digitizer.php
@@ -315,6 +315,7 @@ class Digitizer extends DataManagerElement
             'allowCustomStyle' => false,
             // @todo: may not need configurability at all. Who doesn't want this?
             'allowChangeVisibility' => true,
+            'continueDrawingAfterSave' => false,
             'displayPermanent' => false,
             'printable' => false,
             'inlineSearch' => true,

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -366,11 +366,15 @@
             }
             this.commitGeometry(schema, feature);
             this.selectControl.getFeatures().clear();
-            this.toolsetRenderer.resume();
             if (schema.allowDigitize) {
                 this.featureEditor.setEditFeature(null);
+                if (!schema.continueDrawingAfterSave && this.activeToolName_) {
+                    this._toggleDrawingTool(schema, this.activeToolName_, false);
+                    $('.-fn-toggle-tool', this.element).removeClass('active');
+                }
                 this.featureEditor.resume();
             }
+            this.toolsetRenderer.resume();
             this.resumeContextMenu_();
             var olMap = this.mbMap.getModel().olMap;
             $(olMap).trigger({type: "Digitizer.FeatureUpdatedOnServer", feature: feature});   // why?

--- a/Resources/public/mapbender.element.digitizer.js
+++ b/Resources/public/mapbender.element.digitizer.js
@@ -442,7 +442,7 @@
             }
             var widget = this;
             var idProperty = this._getUniqueItemIdProperty(schema);
-            this.postJSON('update-multiple?' + $.param(params), postData)
+            var promise = this.postJSON('update-multiple?' + $.param(params), postData)
                 .then(function(response) {
                     var savedItems = response.saved;
                     for (var i = 0; i < savedItems.length; ++i) {
@@ -459,6 +459,14 @@
                     $.notify(Mapbender.trans('mb.data.store.save.successfully'), 'info');
                 })
             ;
+            if (!schema.continueDrawingAfterSave) {
+                promise.always(function() {
+                    if (widget.activeToolName_) {
+                        widget._toggleDrawingTool(schema, widget.activeToolName_, false);
+                    }
+                    $('.-fn-toggle-tool', widget.element).removeClass('active');
+                });
+            }
         },
         getSchemaLayer: function(schema) {
             return this.renderer.getLayer(schema);


### PR DESCRIPTION
Adds configurability for keeping the drawing tool active after saving a feature. 1.4 introduced this behaviour to ease bulk creation of features, but depending on usage scenarios, this may cause some confusion.

New schema-level boolean variable `continueDrawingAfterSave` is introduced. If `true`, behaviour remains as in previous 1.4 series Digitizer releases, i.e. after creating a new feature, the drawing tool remains active. If `false` (default), the drawing tool deactivates after saving.

If `false`, drawing tools (including feature moving and vertex editing) will also deactivate after bulk save.

Example usage in schema config:
```yaml
            poi:
                label: Point digitizing
                continueDrawingAfterSave: true
                <...>
```
