### PR TITLE
Update StyleAdapter.js

### DIFF
--- a/Resources/public/StyleAdapter.js
+++ b/Resources/public/StyleAdapter.js
@@ -119,6 +119,17 @@
             var textStyle = this.getDefaultTextStyle();
             textStyle.setFont(this.canvasFontRuleFromSvg(ol2Style));
             this.resolveTextStyle_(textStyle, ol2Style);
+            if (ol2Style.labelOutlineColor) {
+                var rgb = Mapbender.StyleUtil.parseCssColor(ol2Style.labelOutlineColor).slice(0, 3);
+                var opacity = (typeof ol2Style.labelOutlineOpacity !== 'undefined') ? parseFloat(ol2Style.labelOutlineOpacity) : 1;
+                if (!isNaN(opacity)) {
+                    rgb.push(opacity);
+                }
+                textStyle.setStroke(new ol.style.Stroke({
+                    color: rgb,
+                    width: ol2Style.labelOutlineWidth || 1
+                }));
+            }
             return textStyle;
         },
         getIconStyle: function(styleConfig) {


### PR DESCRIPTION
OpenLayers 2 used to have the property "labelOutlineColor" for style definition. To ensure compatibility of the configuration with earlier versions, StyleAdapter converts OL2 Styles in contemporary Open Layers Style Objects - now "labelOutlineColor" as well.