### PR TITLE
Make paging configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Repair Radiobutton ([PR#98](https://github.com/mapbender/mapbender-digitizer/pull/98))
 * Add default whitepace: pre-line in text fields to keep formatting ([PR#98](https://github.com/mapbender/mapbender-digitizer/pull/98))
 * Allow to set text area height by providing row attribute  ([PR#98](https://github.com/mapbender/mapbender-digitizer/pull/98))
-
+* Add option `paging` on root level to disable paging ([PR#99](https://github.com/mapbender/mapbender-digitizer/pull/99))
 
 ## 1.5.7
 * Rewrite context menu for Openlayers 7 compatibility

--- a/src/Mapbender/DataManagerBundle/Resources/public/TableRenderer.js
+++ b/src/Mapbender/DataManagerBundle/Resources/public/TableRenderer.js
@@ -125,15 +125,16 @@
             if (buttonColumnOptions) {
                 columnsOption.push(buttonColumnOptions);
             }
+
             var settings = {
                 columns: columnsOption,
                 lengthChange: false,
-                pageLength: (schema.table || {}).pageLength || 16,
-                searching: (schema.table || {}).searching || (typeof ((schema.table || {}).searching) === 'undefined'),
+                pageLength: schema.pageLength || 16,
+                searching: schema.inlineSearch ?? true,
                 info:         true,
                 processing:   false,
                 ordering:     true,
-                paging:       true,
+                paging:       schema.paging ?? true,
                 selectable:   false,
                 oLanguage: this.getOLanguageOption(schema),
                 autoWidth:    false

--- a/src/Mapbender/DigitizerBundle/Component/SchemaFilter.php
+++ b/src/Mapbender/DigitizerBundle/Component/SchemaFilter.php
@@ -91,16 +91,7 @@ class SchemaFilter extends \Mapbender\DataManagerBundle\Component\SchemaFilter
         if (!empty($schemaConfig['tableFields'])) {
             $schemaConfig['table'] += array('columns' => $schemaConfig['tableFields']);
         }
-        if (isset($schemaConfig['inlineSearch'])) {
-            $schemaConfig['table']['searching'] = $schemaConfig['inlineSearch'];
-        }
-        if (!empty($schemaConfig['pageLength'])) {
-            $schemaConfig['table']['pageLength'] = $schemaConfig['pageLength'];
-        }
-
         unset($schemaConfig['tableFields']);
-        unset($schemaConfig['inlineSearch']);
-        unset($schemaConfig['pageLength']);
 
         // resolve aliasing DM "allowEdit" vs historical Digitizer "allowEditData"
         if (\array_key_exists('allowEditData', $schemaConfig)) {


### PR DESCRIPTION
Add option `paging` on root level to disable paging in a DataManager or digitizer.

Summary of table-behaviour related fields, all on the root level:

| name        | default           | description  |
| ------------- |:-------------:| -----:|
| `paging`      | `true` | defines whether results should be paginated |
| `pageLength`   | 16      |  defines the number of results per page |
| `inlineSearch` | `true`    |  controls whether a search field is shown above the table allowing to filter within the displayed information |

Example configuration:

```yaml
poi:
  label: 'A digitizer'
  featureType:
    connection: geodata_db
    table: poi
    uniqueId: gid
    geomType: point
    geomField: geom
    srid: 25832
    filter: 'st_isempty(geom) = false'
  allowEditData: true
  allowDelete: true
  inlineSearch: false
  paging: false

```