### PR TITLE
allow attribute useValuesAsKeys

### DIFF
--- a/src/Mapbender/DataManagerBundle/Component/FormItemFilter.php
+++ b/src/Mapbender/DataManagerBundle/Component/FormItemFilter.php
@@ -98,7 +98,7 @@ class FormItemFilter
                     );
                 } else {
                     $option = array(
-                        'value' => $key,
+                        'value' => ($item["useValuesAsKeys"] ?? false) ? $mapped : $key,
                         'label' => $mapped,
                     );
                     if (!$warnedAmbiguous) {


### PR DESCRIPTION
Allows to use

```
      options:
        - abc
        - def
```

instead of         
        
```
      options:
        - 
          option:
            key: 
            label: abc
        - 
          option:
            key: def 
            label: def
```