### PR TITLE
Fix/enable data integrity after saving in data manager

### DIFF
--- a/src/Mapbender/DataManagerBundle/Resources/public/dataManager.element.js
+++ b/src/Mapbender/DataManagerBundle/Resources/public/dataManager.element.js
@@ -367,7 +367,9 @@
          * @private
          */
         _afterSave: function(schema, dataItem, originalId, responseData) {
-            this._replaceItemData(schema, dataItem, responseData.dataItem);
+            if (responseData.dataItem) {
+                this._replaceItemData(schema, dataItem, responseData.dataItem.properties);
+            }
             if (!originalId) {
                 // new item
                 this.tableRenderer.addRow(dataItem, true);

--- a/src/Mapbender/DataManagerBundle/Resources/public/dataManager.element.js
+++ b/src/Mapbender/DataManagerBundle/Resources/public/dataManager.element.js
@@ -731,7 +731,7 @@
                 options_.data = JSON.stringify(data);
             }
             this.$loadingIndicator_.css({opacity: 1});
-            return this.decorateXhr_($.ajax(options_, this.$loadingIndicator_));
+            return this.decorateXhr_($.ajax(options_), this.$loadingIndicator_);
         },
         decorateXhr_: function(jqXhr, $loadingIndicator) {
             if ($loadingIndicator) {


### PR DESCRIPTION
When saving a feature in Data-Manager, two issues were addressed:

1. The spinning wheel indicating the saving process failed to disappear.
2. The feature's data wasn't updated within the frontend scope. Specifically, a value in the edit form was updated from "abc" to "xyz" and saved successfully. However, upon immediately reopening the feature's edit dialog, the changed value still displayed as "abc," despite the underlying value in the database having already been updated.

These issues were resolved in this pull request.