### PR TITLE
Feature/enable creation of several features at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## next release
+* updateMultiple now returns a Promise; TableRenderer includes addOrRefreshRow for automatic feature handling post-AJAX call; unique namespace ID for unsaved features enables updates post-AJAX; oldGeometry set after successful updateMultiple call. ([PR#133](https://github.com/mapbender/mapbender-digitizer/pull/133))
 * prevent Draw Donut On Non-Digitizer Features ([PR#120](https://github.com/mapbender/mapbender-digitizer/pull/120))
 * Prevent self intersection of polygons not only on modification, but on creation as well ([PR#118](https://github.com/mapbender/mapbender-digitizer/pull/118))
 * Allow leaving modification mode on pressing escape ([PR#118](https://github.com/mapbender/mapbender-digitizer/pull/118))

--- a/src/Mapbender/DataManagerBundle/Resources/public/TableRenderer.js
+++ b/src/Mapbender/DataManagerBundle/Resources/public/TableRenderer.js
@@ -96,6 +96,23 @@
             }
         },
         /**
+         * @param {Object} item
+         * @param {Boolean} show to automatically update pagination
+         */
+        addOrRefreshRow: function(item, show) {
+            var dt = this.getDatatablesInstance_();
+
+            var rowExists = dt.rows(function(_, data) {
+                return data === item;
+            }).count() > 0;
+
+            if (rowExists) {
+                this.refreshRow(item, show);
+            } else {
+                this.addRow(item, show);
+            }
+        },
+        /**
          * Switch pagination so the given tr element is on the current page
          *
          * @param {Element} tr

--- a/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
+++ b/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
@@ -439,8 +439,8 @@
          * @return {string}
          * @private
          */
-        _generateNamespacedId: function(schema, feature) {
-            return [this.element.attr('id'), schema.schemaName, this._getUniqueItemId(feature)].join('-');
+        _generateNamespacedId: function(schema, feature, index = null) {
+            return [this.element.attr('id'), schema.schemaName, this._getUniqueItemId(feature), ...(index !== null ? [index] : [])].join('-');
         },
         _afterSave: function(schema, feature, originalId, responseData) {
             // unravel dm-incompatible response format
@@ -515,7 +515,7 @@
                 var feature = features[i];
                 var itemSchema = this.getItemSchema(feature);
                 continueDrawing = continueDrawing || itemSchema.continueDrawingAfterSave;
-                var mapId = this._generateNamespacedId(itemSchema, feature);
+                var mapId = this._generateNamespacedId(itemSchema, feature, i);
                 featureMap[mapId] = feature;
                 postData.features.push({
                     schemaName: itemSchema.schemaName,
@@ -538,7 +538,8 @@
                         feature.setGeometry(geometry);
                         widget._replaceItemData(itemSchema, feature, savedItem.properties || {});
                         feature.set('dirty', false);
-                        widget.tableRenderer.refreshRow(feature, false);
+                        feature.set('oldGeometry', geometry);
+                        widget.tableRenderer.addOrRefreshRow(feature, true);
                         widget._saveEvent(itemSchema, feature, widget._getUniqueItemId(feature));
                     }
                     $.notify(Mapbender.trans('mb.data.store.save.successfully'), 'info');

--- a/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
+++ b/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
@@ -554,6 +554,8 @@
                     $('.-fn-toggle-tool', widget.element).removeClass('active');
                 });
             }
+
+            return promise;
         },
         updateSaveAll: function() {
             var $saveAllButton = $('.-fn-save-all', this.element);


### PR DESCRIPTION
Added additional functionality:

* The updateMultiple method now returns a Promise.
* The TableRenderer includes an addOrRefreshRow method that automatically handles whether a feature already exists in the table. This method is called after a successful updateMultiple AJAX call.
* A unique namespace ID is also generated for unsaved features to ensure they can be updated once the AJAX request successfully stores them.
* The oldGeometry attribute is set after a successful updateMultiple call.

These are non-breaking changes that should not affect the former processing of existing features being updated.