### PR TITLE
Bugfixes concerning the allow* schema settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 * updateMultiple now returns a Promise; TableRenderer includes addOrRefreshRow for automatic feature handling post-AJAX call; unique namespace ID for unsaved features enables updates post-AJAX; oldGeometry set after successful updateMultiple call. ([PR#133](https://github.com/mapbender/mapbender-digitizer/pull/133))
 * prevent Draw Donut On Non-Digitizer Features ([PR#120](https://github.com/mapbender/mapbender-digitizer/pull/120))
 * Enable CSS styling in FormItem for images, and allow images to be displayed in their original size with the EnlargeImage attribute ([PR#134](https://github.com/mapbender/mapbender-digitizer/pull/134)) 
+* Digitizer showed tool icons to edit feature-geometries even when digitizing is disabled ([#1647](https://github.com/mapbender/mapbender/issues/1647), [PR#135](https://github.com/mapbender/mapbender-digitizer/pull/135))
+* Saving new geometries was not possible when allowEdit was not set ([PR#135](https://github.com/mapbender/mapbender-digitizer/pull/135))
 
 ## 2.0.2
 * Enable creation of several features at once ([PR#131](https://github.com/mapbender/mapbender-digitizer/pull/131))

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Using Digitizer requires registering *two* bundles in your application kernel. R
 ## Configuring feature interactions
 Each schema may define the following values to control access to data modifying interactions:
 
-| name | type | description | default |
-|---|---|---|---|
-| allowCreate | boolean or list of strings | Allow user to make new features | true |
-| allowEdit | boolean or list of strings | Allow user to modify existing features and their attributes | true |
-| allowDelete | boolean or list of strings | Allow user to remove features from the database | true |
-| allowDigitize | boolean or list of strings | Allow geometry editing (attribute editing may still be allowed via `allowEdit`) | true |
-| roles | list of strings or null | Show this schema only to users with (at least one of) these roles | null |
+| name | type | description                                                                     | default |
+|---|---|---------------------------------------------------------------------------------|---|
+| allowCreate | boolean or list of strings | Allow user to make new features                                                 | true |
+| allowEdit | boolean or list of strings | Allow user to modify existing feature attributes                     | true |
+| allowDelete | boolean or list of strings | Allow user to remove features from the database                                 | true |
+| allowDigitize | boolean or list of strings | Allow geometry editing (attribute editing must also be allowed via `allowEdit`) | true |
+| roles | list of strings or null | Show this schema only to users with (at least one of) these roles               | null |
 
 The `roles` list should contain entries understood by the Symfony grants system, such as
 `ROLE_USER` for logged-in users or `ROLE_GROUP_SOMETHING` for a user group created and

--- a/src/Mapbender/DataManagerBundle/Resources/public/dataManager.element.js
+++ b/src/Mapbender/DataManagerBundle/Resources/public/dataManager.element.js
@@ -517,10 +517,10 @@
          * @return {Array<Object>}
          * @private
          */
-        _getEditDialogButtons: function(schema, dataItem) {
+        _getEditDialogButtons: function(schema, dataItem, overrideAllowSave) {
             var buttons = [];
             var widget = this;
-            if (schema.allowEdit) {
+            if (schema.allowEdit || overrideAllowSave) {
                 buttons.push({
                     text: Mapbender.trans('mb.actions.save'),
                     'class': 'btn btn-primary',

--- a/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
+++ b/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
@@ -293,7 +293,7 @@
             var subSchemas = this.expandCombination(schema);
             for (var s = 0; s < subSchemas.length; ++s) {
                 keepVisChange = keepVisChange || subSchemas[s].allowChangeVisibility;
-                keepSaveAll = keepSaveAll || subSchemas[s].allowDigitize || subSchemas[s].allowEdit;
+                keepSaveAll = keepSaveAll || (subSchemas[s].allowDigitize && subSchemas[s].allowEdit);
                 if (keepVisChange && keepSaveAll) {
                     break;
                 }
@@ -419,7 +419,7 @@
         getEnabledSchemaFunctionCodes: function(schema) {
             var codes = this._superApply(arguments);
             codes = codes.concat([
-                schema.allowDigitize && '-fn-save',
+                schema.allowDigitize && schema.allowEdit && '-fn-save',
                 schema.copy && schema.copy.enable && '-fn-copy',
                 schema.allowCustomStyle && '-fn-edit-style',
                 schema.allowChangeVisibility && '-fn-toggle-visibility'

--- a/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
+++ b/src/Mapbender/DigitizerBundle/Resources/public/mapbender.element.digitizer.js
@@ -361,7 +361,8 @@
                     }
                 });
             }
-            buttons.push.apply(buttons, this._super(schema, feature));
+            const overrideShowSaveButton = !this._getUniqueItemId(feature) && schema.allowCreate;
+            buttons.push.apply(buttons, this._super(schema, feature, overrideShowSaveButton));
             return buttons;
         },
         _getItemData: function(feature) {

--- a/src/Mapbender/DigitizerBundle/Resources/public/toolset.js
+++ b/src/Mapbender/DigitizerBundle/Resources/public/toolset.js
@@ -59,16 +59,10 @@
             var seen = {};
             var toolSpecs = [];
             var subSchemas = this.owner.expandCombination(schema);
-            var standardTools = ['modifyFeature', 'moveFeature'];
-            var addModify = false;
             var addMove = false;
             var self = this;
             for (var s = 0; s < subSchemas.length; ++s) {
                 var validNames = this.getValidToolNames(subSchemas[s]);
-                // Note: Modify not allowed on single point geometries
-                //       Move allowed on everything
-                addModify = addModify || -1 !== validNames.indexOf('modifyFeature');
-                addMove = true;
                 var subSchemaTools = (subSchemas[s].toolset || this.getDefaultGeometryToolNames(subSchemas[s])).map(function(tc) {
                     var obj = (typeof tc === 'string') && {type: tc} || Object.assign({}, tc);
                     obj.schema = obj.schema || subSchemas[s].schemaName;
@@ -76,7 +70,6 @@
                 }).filter(function(toolSpec) {
                     return (!seen[toolSpec.type])
                         && self.checkToolAccess_(subSchemas[s], toolSpec.type)
-                        && -1 === standardTools.indexOf(toolSpec.type)
                         && -1 !== validNames.indexOf(toolSpec.type)
                     ;
                 });
@@ -87,12 +80,6 @@
                         seen[toolSpec.type] = true;
                     }
                 }
-            }
-            if (addModify) {
-                toolSpecs.push({type: 'modifyFeature'});
-            }
-            if (addMove) {
-                toolSpecs.push({type: 'moveFeature'});
             }
             return toolSpecs;
         },


### PR DESCRIPTION
- Show save button when allowCreate is true but allowEdit is not (this meant creating new entries was not possible without allowEdit)
- Do not show "modifyFeature" and "moveFeature" tools when allowDigitize is not active (fixes https://github.com/mapbender/mapbender/issues/1647) 

see also [documentation PR](https://github.com/mapbender/mapbender-documentation/pull/520)