### PR TITLE
[DataManager] Add validation for input fields

### DIFF
--- a/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
+++ b/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
@@ -204,7 +204,7 @@ class HttpHandler implements ElementHttpHandlerInterface
             } else {
                 if (array_key_exists('name', $formItem)) {
                     $pattern = (array_key_exists('pattern', $formItem)) ? $formItem['pattern'] : $regexPattern;
-                    if (!preg_match('/' . $pattern . '/', $formItem['name'])) {
+                    if (!preg_match('/' . $pattern . '/u', $formItem['name'])) {
                         throw new BadRequestHttpException('api.query.error-invalid-data');
                     }
                 }

--- a/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
+++ b/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
@@ -167,7 +167,6 @@ class HttpHandler implements ElementHttpHandlerInterface
         $schemaName = $request->query->get('schema');
         /** @var ItemSchema $schema */
         $schema = $this->schemaFilter->getSchema($element, $schemaName);
-
         $requestData = json_decode($request->getContent(), true);
         if ($itemId) {
             // update existing item
@@ -176,6 +175,7 @@ class HttpHandler implements ElementHttpHandlerInterface
             // store new item
             $dataItem = $schema->getRepository()->itemFactory();
         }
+        $this->validateInputData($element->getConfiguration(), $schema->config);
         $itemOut = $this->saveItem($schema, $dataItem, $requestData);
         return array(
             'dataItem' => $this->formatResponseItem($schema, $itemOut),
@@ -188,6 +188,28 @@ class HttpHandler implements ElementHttpHandlerInterface
         $userData = $this->userFilterProvider->getStorageValues($schema, $item);
         $item->setAttributes($userData);
         return $schema->getRepository()->save($item);
+    }
+
+    protected function validateInputData($elementConfig, $schemaConfig)
+    {
+        $regexPattern = $elementConfig['regexPattern'];
+        $this->iterateFormItems($schemaConfig['formItems'], $regexPattern);
+    }
+
+    protected function iterateFormItems($formItems, $regexPattern)
+    {
+        foreach ($formItems as $formItem) {
+            if (array_key_exists('children', $formItem)) {
+                $this->iterateFormItems($formItem['children'], $regexPattern);
+            } else {
+                if (array_key_exists('name', $formItem)) {
+                    $pattern = (array_key_exists('pattern', $formItem)) ? $formItem['pattern'] : $regexPattern;
+                    if (!preg_match('/' . $pattern . '/', $formItem['name'])) {
+                        throw new BadRequestHttpException('api.query.error-invalid-data');
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
+++ b/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
@@ -203,7 +203,7 @@ class HttpHandler implements ElementHttpHandlerInterface
                 $this->iterateFormItems($formItem['children'], $regexPattern, $requestData);
             } else {
                 if (array_key_exists('name', $formItem) && !empty($requestData['properties'][$formItem['name']])) {
-                    $pattern = (array_key_exists('pattern', $formItem)) ? $formItem['pattern'] : $regexPattern;
+                    $pattern = (!empty($formItem['attr']['pattern'])) ? $formItem['attr']['pattern'] : $regexPattern;
                     if (!preg_match('/' . $pattern . '/u', $requestData['properties'][$formItem['name']])) {
                         throw new BadRequestHttpException('api.query.error-invalid-data');
                     }

--- a/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
+++ b/src/Mapbender/DataManagerBundle/Component/HttpHandler.php
@@ -192,18 +192,18 @@ class HttpHandler implements ElementHttpHandlerInterface
 
     protected function validateInputData($elementConfig, $schemaConfig, $requestData)
     {
-        $regexPattern = $elementConfig['regexPattern'];
-        $this->iterateFormItems($schemaConfig['formItems'], $regexPattern, $requestData);
+        $pattern = $elementConfig['pattern'];
+        $this->iterateFormItems($schemaConfig['formItems'], $pattern, $requestData);
     }
 
-    protected function iterateFormItems($formItems, $regexPattern, $requestData)
+    protected function iterateFormItems($formItems, $pattern, $requestData)
     {
         foreach ($formItems as $formItem) {
             if (array_key_exists('children', $formItem)) {
-                $this->iterateFormItems($formItem['children'], $regexPattern, $requestData);
+                $this->iterateFormItems($formItem['children'], $pattern, $requestData);
             } else {
                 if (array_key_exists('name', $formItem) && !empty($requestData['properties'][$formItem['name']])) {
-                    $pattern = (!empty($formItem['attr']['pattern'])) ? $formItem['attr']['pattern'] : $regexPattern;
+                    $pattern = (!empty($formItem['attr']['pattern'])) ? $formItem['attr']['pattern'] : $pattern;
                     if (!preg_match('/' . $pattern . '/u', $requestData['properties'][$formItem['name']])) {
                         throw new BadRequestHttpException('api.query.error-invalid-data');
                     }

--- a/src/Mapbender/DataManagerBundle/Element/DataManager.php
+++ b/src/Mapbender/DataManagerBundle/Element/DataManager.php
@@ -51,7 +51,7 @@ class DataManager extends AbstractElementService
     {
         return array(
             'schemes' => null,
-            'regexPattern' => '^[a-zA-Z0-9_\-\s]*$',
+            'regexPattern' => '^[\p{L}0-9_\-\s]*$'
         );
     }
 

--- a/src/Mapbender/DataManagerBundle/Element/DataManager.php
+++ b/src/Mapbender/DataManagerBundle/Element/DataManager.php
@@ -51,7 +51,7 @@ class DataManager extends AbstractElementService
     {
         return array(
             'schemes' => null,
-            'regexPattern' => '^[\p{L}0-9_\-\s]*$'
+            'pattern' => '^[\p{L}0-9_\-\s]*$'
         );
     }
 

--- a/src/Mapbender/DataManagerBundle/Element/DataManager.php
+++ b/src/Mapbender/DataManagerBundle/Element/DataManager.php
@@ -51,6 +51,7 @@ class DataManager extends AbstractElementService
     {
         return array(
             'schemes' => null,
+            'regexPattern' => '^[a-zA-Z0-9_\-\s]*$',
         );
     }
 

--- a/src/Mapbender/DataManagerBundle/Resources/public/FormRenderer.js
+++ b/src/Mapbender/DataManagerBundle/Resources/public/FormRenderer.js
@@ -482,11 +482,6 @@
                 .attr('name', settings.name || null)
                 .addClass('form-control')
             ;
-            var digitizer = $('.mb-element-digitizer').data('mapbenderMbDigitizer');
-            var regexPattern = (settings.hasOwnProperty('pattern')) ? settings.pattern : digitizer.options.regexPattern;
-            if (!$input.attr('pattern')) {
-                $input.attr('pattern', regexPattern);
-            }
             if (settings.value) {
                 $input.val(settings.value);
             }

--- a/src/Mapbender/DataManagerBundle/Resources/public/FormRenderer.js
+++ b/src/Mapbender/DataManagerBundle/Resources/public/FormRenderer.js
@@ -482,6 +482,11 @@
                 .attr('name', settings.name || null)
                 .addClass('form-control')
             ;
+            var digitizer = $('.mb-element-digitizer').data('mapbenderMbDigitizer');
+            var regexPattern = (settings.hasOwnProperty('pattern')) ? settings.pattern : digitizer.options.regexPattern;
+            if (!$input.attr('pattern')) {
+                $input.attr('pattern', regexPattern);
+            }
             if (settings.value) {
                 $input.val(settings.value);
             }

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.de.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.de.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Fehler
   api.query.error-notloggedin: "Bitte loggen Sie sich ein"
   api.query.error-database: "Verbindung zur Datenbank konnte nicht hergestellt werden. Überprüfen Sie die Konfiguration in 'featureType'"
+  api.query.error-invalid-data: 'Ungültige Eingabe'
 
 mb.data-manager.table:
   filter: Durchsuchen

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.en.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.en.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Error
   api.query.error-notloggedin: "Please sign in"
   api.query.error-database: "Connection to the database could not be established. Check the configuration in 'featureType'"
+  api.query.error-invalid-data: 'Invalid input'
 
 mb.data-manager.table:
   filter: Filter

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.es.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.es.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Error
   api.query.error-notloggedin: "Por favor, inicia sesión"
   api.query.error-database: "No se ha podido establecer la conexión con la base de datos. Compruebe la configuración en 'featureType'."
+  api.query.error-invalid-data: 'Entrada no válida'
 
 mb.data-manager.table:
   filter: Filtro

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.fr.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.fr.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Erreur
   api.query.error-notloggedin: "Veuillez vous connecter"
   api.query.error-database: "La connexion à la base de données n'a pas pu être établie. Vérifiez la configuration dans 'featureType'"
+  api.query.error-invalid-data: 'Entrée non valide'
 
 mb.data-manager.table:
   filter: Filtre

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.it.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.it.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Errore
   api.query.error-notloggedin: "Effettua il login, per favore"
   api.query.error-database: "Impossibile connettersi al database. Controlla la configurazione in 'featureType'"
+  api.query.error-invalid-data: 'Input non valido'
 
 mb.data-manager.table:
   filter: Cerca

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.nl.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.nl.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Fout
   api.query.error-notloggedin: "Graag inloggen"
   api.query.error-database: "Verbinding met de database kon niet worden gemaakt. Controleer de configuratie in 'featureType'"
+  api.query.error-invalid-data: 'Ongeldige invoer'
 
 mb.data-manager.table:
   filter: Filter

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.pl.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.pl.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Błąd
   api.query.error-notloggedin: "Proszę się zalogować"
   api.query.error-database: "Nie można nawiązać połączenia z bazą danych. Sprawdź konfigurację w 'featureType'"
+  api.query.error-invalid-data: 'Invalid input'
 
 mb.data-manager.table:
   filter: Filtr

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.pt.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.pt.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Erro
   api.query.error-notloggedin: Por favor, faça login
   api.query.error-database:  Não foi possível conectar ao banco de dados. Verifique a configuração em 'featureType'
+  api.query.error-invalid-data: 'Entrada inválida'
 
 mb.data-manager.table:
   filter: Filtrar

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.tr.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.tr.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Hata
   api.query.error-notloggedin: "Lütfen giriş yapın"
   api.query.error-database: "Veritabanına bağlantı kurulamadı. 'featureType' içindeki yapılandırmayı kontrol edin"
+  api.query.error-invalid-data: 'Geçersiz giriş'
 
 mb.data-manager.table:
   filter: Filtre

--- a/src/Mapbender/DataManagerBundle/Resources/translations/messages.uk.yaml
+++ b/src/Mapbender/DataManagerBundle/Resources/translations/messages.uk.yaml
@@ -7,6 +7,7 @@ mb.data.store:
   api.query.error-message: Помилка
   api.query.error-notloggedin: "Будь ласка, увійдіть в систему"
   api.query.error-database: "Не вдалося встановити з'єднання з базою даних. Перевірте конфігурацію в 'featureType'"
+  api.query.error-invalid-data: 'Неправильний ввід'
 
 mb.data-manager.table:
   filter: Фільтр


### PR DESCRIPTION
Adds a validation for all input fields with the following regex: `^[\p{L}0-9_\-\s@]*$`

Can be overwritten selectively by adding the pattern attribute to the digitizer's yaml configuration: 

   ```
 -
      type: input
      title: E-Mail
      name: email
      css: { width: 40% }
      attr:
          pattern: '^[\p{L}0-9_\-\s@]*$'
```
pattern attribute existed before, see: https://doc.mapbender.org/en/elements/editing/digitizer/digitizer_configuration.html#customization-by-attr-object-definitions 