### PR TITLE
Add support for parameter `roles` in featureType filter and `groupRoles` for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## next minor release
+* Add support for parameter `roles` in featureType filter ([PR#158](https://github.com/mapbender/mapbender-digitizer/pull/158))
+
+
 ## 2.0.8
 * Add support for DataTables version 2 ([PR#150](https://github.com/mapbender/mapbender-digitizer/pull/150)), [PR#154](https://github.com/mapbender/mapbender-digitizer/pull/154)
 * Show message after asynchronous requests for expired sessions with option to retry ([PR#151](https://github.com/mapbender/mapbender-digitizer/pull/151))

--- a/src/Mapbender/DataSourceBundle/Component/DataRepository.php
+++ b/src/Mapbender/DataSourceBundle/Component/DataRepository.php
@@ -4,7 +4,9 @@
 namespace Mapbender\DataSourceBundle\Component;
 
 
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Mapbender\DataManagerBundle\Exception\ConfigurationErrorException;
 use Mapbender\DataSourceBundle\Component\Drivers\DoctrineBaseDriver;
@@ -349,12 +351,16 @@ class DataRepository
     {
         $setUserParam = false;
         $userNamePattern = '#:userName([^_\w\d]|$)#';
+        $setRolesParam = false;
+        $rolesPattern = '#:roles([^_\w\d]|$)#';
         if ($includeDefaultFilter && !empty($this->sqlFilter)) {
             $setUserParam = !!preg_match($userNamePattern, $this->sqlFilter);
+            $setRolesParam = !!preg_match($rolesPattern, $this->sqlFilter);
             $queryBuilder->andWhere($this->sqlFilter);
         }
         if (!empty($params['where'])) {
             $setUserParam = $setUserParam || preg_match($userNamePattern, $params['where']);
+            $setRolesParam = $setRolesParam || preg_match($rolesPattern, $params['where']);
             $queryBuilder->andWhere($params['where']);
         }
         if ($setUserParam) {
@@ -365,6 +371,14 @@ class DataRepository
             } else {
                 // No authenticated user, use empty string or anonymous
                 $queryBuilder->setParameter('userName', '');
+            }
+        }
+        if ($setRolesParam) {
+            $token = $this->tokenStorage->getToken();
+            if ($token !== null && !$token instanceof NullToken) {
+                $queryBuilder->setParameter('roles', $token->getRoleNames(), ArrayParameterType::STRING);
+            } else {
+                $queryBuilder->setParameter('roles', [], ArrayParameterType::STRING);
             }
         }
     }

--- a/src/Mapbender/DataSourceBundle/Component/EventProcessor.php
+++ b/src/Mapbender/DataSourceBundle/Component/EventProcessor.php
@@ -24,7 +24,7 @@ class EventProcessor
     public $allowRemove = true;
 
     public function __construct(AuthorizationCheckerInterface $authorizationChecker,
-                                TokenStorageInterface $tokenStorage)
+                                TokenStorageInterface         $tokenStorage)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->tokenStorage = $tokenStorage;
@@ -75,18 +75,20 @@ class EventProcessor
     protected function addBuiltins(array $locals)
     {
         $token = $this->tokenStorage->getToken();
-        
+
         $locals += array(
             'context' => $this->authorizationChecker,
             'tokenStorage' => $this->tokenStorage,
             'user' => ($token !== null && !$token instanceof NullToken) ? $token->getUser() : null,
-            'userRoles' => array(),
+            'userRoles' => [],
+            'groupRoles' => [],
         );
 
         if ($token !== null && !$token instanceof NullToken) {
             if (\method_exists($token, 'getRoleNames')) {
                 // Symfony >= 4.3
                 $locals['userRoles'] = $token->getRoleNames();
+                $locals['groupRoles'] = array_filter($token->getRoleNames(), fn($r) => str_starts_with('ROLE_GROUP_', $r));
             } else {
                 foreach ($token->getRoles() as $role) {
                     if (\is_object($role) && \method_exists($role, 'getRole')) {
@@ -96,6 +98,9 @@ class EventProcessor
                         $roleName = \strval($role);
                     }
                     $locals['userRoles'][] = $roleName;
+                    if (str_starts_with($roleName, 'ROLE_GROUP_')) {
+                        $locals['groupRoles'][] = $roleName;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Can be used to managed the access to digitizer entries based on mapbender groups.

In the filter query you can use the additional parameter `:roles`, which is prefilled with all the currently logged-in users groups (including ROLE_USER when the user is logged in).

In an event, you can use the additional variable `$groupRoles` (in addition to `$userRoles`) which contains only the roles starting with `ROLE_GROUP`, excluding e.g. ROLE_USER. 

Example configuration (assuming in the digitizer table there's a column `mapbender_group`):

```yaml
groupfilteredtable:
  label: Group filtered table
  maxResults: 500
  featureType:
    connection: geodb
    table: geotable
    uniqueId: gid
    geomType: point
    geomField: geom
    srid: 25832
    filter: 'mapbender_group in (:roles)'
    events:
      onBeforeSave: "$feature->setAttribute('mapbender_group', implode(', ', $groupRoles));"
```

